### PR TITLE
Change default port to Vite v3+ default

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -193,7 +193,7 @@ export default function viteNodeCGPlugin(pluginConfig: PluginConfig): Plugin {
                 typeof _config?.server?.host === 'string'
                     ? _config?.server?.host
                     : 'localhost'
-            }:${_config?.server?.port?.toString() ?? '3000'}`
+            }:${_config?.server?.port?.toString() ?? '5173'}`
 
             return {
                 build: {


### PR DESCRIPTION
They changed the default dev port from `3000` to `5173` in Vite v3 but I forgot to update it in my old PR, so here's that fix.

There's some more issues with that dev port I'd like to fix, currently covered in #4 but as I had difficulty with those, decided to make this it's own PR.